### PR TITLE
add docker build & instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22
+
+WORKDIR /app
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    libgtk-3-0 \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libxtst6 \
+    xvfb \
+    wine64 \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# We'll mount the project directory as a volume
+# This allows for the build artifacts to be accessible from the host
+
+CMD ["bash"] 

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,0 +1,65 @@
+# Docker Setup for PasteMax
+
+This guide explains how to use Docker for building the PasteMax Electron application.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Setup and Usage
+
+### 1. Build the Docker Image
+
+```bash
+docker compose build
+```
+
+### 2. Start and enter the Container
+
+```bash
+docker compose run --rm pastemax-dev bash
+```
+
+### 3. Inside the Container
+
+Once inside the container, you can run the build commands:
+
+```bash
+# Install dependencies
+npm install
+
+# Package the application for your platform
+npm run package:win    # For Windows
+npm run package:mac    # For macOS
+npm run package:linux  # For Linux
+npm run package:all    # For all platforms
+```
+
+### 4. Ensure the host can access the built artifacts
+
+From the host, run:
+```bash
+chmod -R 777 release-builds
+```
+
+### 5. Run the Application
+
+The built application will be available in the `release-builds` directory on your host machine. You can run it directly from there.
+
+For example, on Windows, it is built at:
+```
+`.\pastemax\release-builds\win-unpacked\PasteMax.exe`
+```
+
+## Workflow
+
+1. Develop and edit code on your host machine
+2. Use the container for building and packaging
+3. Run the packaged application on your host machine
+
+## Notes
+
+- This setup is for building only. The Electron app cannot run inside the container with a GUI.
+- The project directory is mounted as a volume, so any changes you make on your host are immediately available in the container.
+- Build artifacts created in the container are immediately available on your host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  pastemax-dev:
+    build: .
+    volumes:
+      - .:/app
+    working_dir: /app
+    tty: true
+    stdin_open: true
+    command: bash

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "electron",
     "file-viewer"
   ],
-  "author": "kleneway",
+  "author": {
+    "name": "kleneway",
+    "email": "kleneway@notreal.com"
+  },
   "license": "MIT",
   "description": "A modern file viewer application for developers to easily navigate, search, and copy code from repositories.",
   "build": {


### PR DESCRIPTION
Great FOSS tool, @kleneway ! 

I encountered basically one error while trying to build this within a docker container on windows, something complained that there was no email for the author in package.json. So I added a fake email.

Other than that, this just adds a simple dockerfile that installs the prereqs to build an electron app, and a file with instructions on how to build on various platforms using the containerized build. I didn't test on any platform except windows.

Got it working for Windows:
![image](https://github.com/user-attachments/assets/ce60521e-e27f-4f3e-94a7-b37bbac8336f)
