### PR TITLE
Improve Update Checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [1.0.9] - 2025-05-17
+
+### Added
+
+- **Automatic Update Checker:**
+
+  - Automatically check for new updates from the latest GitHub release.
+  - The update checker is fired up on app launch and can be triggered manually from the header.
+  - The update status is displayed in a modal with clear download links for the latest release.
+
+- **Update Checker UI Enhancements:**
+  - The update check button in the header now uses the same base styles as the modal's `.check-updates-button` (from `UpdateModal.css`) when no update is available.
+  - When an update is available, the button's background and text color are overridden to use `backgroundColor: var(--color-accent, #0e639c)` and `color: var(--color-accent, #ffffff)`.
+  - The "Update Available!" label is now positioned directly below the update button and styled for visibility.
+
+### Changed
+
+- **Update Checker Behavior:**
+  - The automatic update check on app launch is now disabled in development mode (`process.env.NODE_ENV === 'development'`). In dev, the renderer receives a "no update" status immediately.
+  - The update check button's style logic in `src/App.tsx` was refactored to conditionally apply override styles only when an update is available.
+
+### Fixed
+
+- **UI Consistency:**
+  - Ensured the update check button in the header matches the modal's button style when no update is available.
+  - Fixed the position of the "Update Available!" label so it always appears directly below the update button.
+
 ## [1.0.8] - 2025-05-17
 
 ### Changed

--- a/electron/main.js
+++ b/electron/main.js
@@ -540,17 +540,27 @@ function createWindow() {
     mainWindow.webContents.send('startup-mode', {
       safeMode: isSafeMode,
     });
-    // Automatic update check on app launch
-    try {
-      const { getUpdateStatus } = require('./update-manager');
-      const updateStatus = await getUpdateStatus();
-      mainWindow.webContents.send('initial-update-status', updateStatus);
-    } catch (err) {
+    // Automatic update check on app launch (skip in development mode)
+    if (process.env.NODE_ENV !== 'development') {
+      try {
+        const { getUpdateStatus } = require('./update-manager');
+        const updateStatus = await getUpdateStatus();
+        mainWindow.webContents.send('initial-update-status', updateStatus);
+      } catch (err) {
+        mainWindow.webContents.send('initial-update-status', {
+          isUpdateAvailable: false,
+          currentVersion: app.getVersion(),
+          error: err?.message || 'Failed to check for updates on launch',
+          isLoading: false,
+        });
+      }
+    } else {
+      // In development mode, just send a "no update" status immediately
       mainWindow.webContents.send('initial-update-status', {
         isUpdateAvailable: false,
         currentVersion: app.getVersion(),
-        error: err?.message || 'Failed to check for updates on launch',
         isLoading: false,
+        error: undefined,
       });
     }
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1366,27 +1366,9 @@ const App = (): JSX.Element => {
                 }}
               >
                 <button
-                  className="header-action-btn check-updates-button"
+                  className={`header-action-btn check-updates-button${initialAutoUpdateResult?.isUpdateAvailable && !isUpdateModalOpen ? ' update-available' : ''}`}
                   title="Check for application updates"
                   onClick={handleCheckForUpdates}
-                  style={
-                    // When the update is available, change the button color
-                    initialAutoUpdateResult?.isUpdateAvailable && !isUpdateModalOpen
-                      ? {
-                          backgroundColor: 'var(--color-accent, #0e639c)',
-                          color: 'var(--color-accent, #ffffff)',
-                          padding: 4,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                        }
-                      : {
-                          padding: 4,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                        }
-                  }
                 >
                   <DownloadCloud size={16} />
                 </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1369,12 +1369,24 @@ const App = (): JSX.Element => {
                   className="header-action-btn check-updates-button"
                   title="Check for application updates"
                   onClick={handleCheckForUpdates}
-                  style={{
-                    padding: 4,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
+                  style={
+                    // When the update is available, change the button color
+                    initialAutoUpdateResult?.isUpdateAvailable && !isUpdateModalOpen
+                      ? {
+                          backgroundColor: 'var(--color-accent, #0e639c)',
+                          color: 'var(--color-accent, #ffffff)',
+                          padding: 4,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }
+                      : {
+                          padding: 4,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }
+                  }
                 >
                   <DownloadCloud size={16} />
                 </button>

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 export interface UpdateCheckResultFromMain {
   isUpdateAvailable: boolean;
@@ -20,100 +20,12 @@ interface UpdateModalProps {
   updateStatus: UpdateDisplayState | null;
 }
 
-const checkForUpdates = async (): Promise<UpdateDisplayState> => {
-  if (!window.electron?.ipcRenderer?.invoke) {
-    return {
-      isLoading: false,
-      isUpdateAvailable: false,
-      currentVersion: '',
-      error: 'Electron IPC not available',
-    };
-  }
-  try {
-    const result = await window.electron.ipcRenderer.invoke('check-for-updates');
-    return {
-      ...result,
-      isLoading: false,
-    };
-  } catch (error: any) {
-    return {
-      isLoading: false,
-      isUpdateAvailable: false,
-      currentVersion: '',
-      error: error?.message || 'Unknown error during IPC invoke',
-      debugLogs: error?.stack || (typeof error === 'string' ? error : 'IPC invoke failed'),
-    };
-  }
-};
-
-const UpdateModal = ({ isOpen, onClose, updateStatus: externalUpdateStatus }: UpdateModalProps) => {
-  const [updateStatus, setUpdateStatus] = useState(
-    externalUpdateStatus as UpdateDisplayState | null
-  );
-  const [isRetryOnCooldown, setIsRetryOnCooldown] = useState(false);
-  const [sessionRetryAttempts, setSessionRetryAttempts] = useState(0);
-  const MAX_BUTTON_CLICKS_PER_MODAL_SESSION = 2;
-
-  // Sync with external updateStatus prop
-  React.useEffect(() => {
-    setUpdateStatus(externalUpdateStatus);
-    if (externalUpdateStatus && !externalUpdateStatus.isLoading) {
-      if (
-        !externalUpdateStatus.error ||
-        externalUpdateStatus.error?.includes('Maximum update check attempts')
-      ) {
-        setSessionRetryAttempts(0);
-      }
-    }
-  }, [externalUpdateStatus]);
-
+const UpdateModal = ({ isOpen, onClose, updateStatus }: UpdateModalProps) => {
   const handleDownloadUpdate = useCallback(() => {
     if (updateStatus?.releaseUrl) {
       window.open(updateStatus.releaseUrl, '_blank');
     }
   }, [updateStatus]);
-
-  const handleRecheck = useCallback(async () => {
-    if (isRetryOnCooldown || (updateStatus?.isLoading ?? false)) return;
-    if (
-      sessionRetryAttempts >= MAX_BUTTON_CLICKS_PER_MODAL_SESSION &&
-      updateStatus?.error &&
-      !updateStatus.error.includes('Maximum update check attempts')
-    ) {
-      return;
-    }
-
-    setIsRetryOnCooldown(true);
-    setSessionRetryAttempts((prev: number) => prev + 1);
-
-    setUpdateStatus(
-      (prev: UpdateDisplayState | null): UpdateDisplayState => ({
-        ...(prev || { currentVersion: '', isUpdateAvailable: false }),
-        isLoading: true,
-        error: undefined,
-      })
-    );
-
-    const result = await checkForUpdates();
-    setUpdateStatus(result);
-
-    const cooldownDuration = result.error?.includes('403') ? 60000 : result.error ? 10000 : 1000;
-    setTimeout(() => {
-      setIsRetryOnCooldown(false);
-    }, cooldownDuration);
-  }, [isRetryOnCooldown, updateStatus, sessionRetryAttempts]);
-
-  const retryButtonDisabled =
-    (updateStatus?.isLoading ?? false) ||
-    isRetryOnCooldown ||
-    updateStatus?.error?.includes('Maximum update check attempts reached');
-
-  const retryButtonText = updateStatus?.error?.includes('Maximum update check attempts reached')
-    ? 'Restart to Check'
-    : 'Retry';
-  const recheckButtonText = updateStatus?.error?.includes('Maximum update check attempts reached')
-    ? 'Restart to Check'
-    : 'Re-check';
 
   if (!isOpen) {
     return null;

--- a/src/styles/modals/UpdateModal.css
+++ b/src/styles/modals/UpdateModal.css
@@ -131,9 +131,9 @@
 }
 
 .check-updates-button {
-  background-color: var(--color-primary);
-  color: var(--text-on-primary);
-  border-color: var(--color-primary);
+  background-color: var(--hover-color);
+  color: var(--text-primary);
+  border-color: var(--border-color);
   border-radius: var(--border-radius-md);
   font-weight: 600;
   font-size: var(--font-size-sm);
@@ -146,6 +146,7 @@
 
 .check-updates-button:hover {
   background-color: var(--hover-color);
+  border-color: var(--color-primary);
   color: var(--text-primary);
   transition:
     all 0.2s var(--animation-curve),

--- a/src/styles/modals/UpdateModal.css
+++ b/src/styles/modals/UpdateModal.css
@@ -174,3 +174,17 @@
     all 0.2s var(--animation-curve),
     background-color 0.3s ease;
 }
+
+/* Styles for the Check for Updates button in the main app header */
+.header-action-btn.check-updates-button {
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Highlighted state when update is available */
+.header-action-btn.check-updates-button.update-available {
+  background-color: var(--color-primary);
+  color: var(--text-on-primary);
+}


### PR DESCRIPTION
### Added

- **Automatic Update Checker:**

  - Automatically check for new updates from the latest GitHub release.
  - The update checker is fired up on app launch and can be triggered manually from the header.
  - The update status is displayed in a modal with clear download links for the latest release.
  - Disabled on `dev` mode to prevent API exhaust.

- **Update Checker UI Enhancements:**
  - The update check button in the header now uses the same style as other buttons when no update is available.
  - When an update is available, the button's background and text color are overridden to use `backgroundColor: var(--color-accent, #0e639c)` and `color: var(--color-accent, #ffffff)`.
  - A new "Update Available!" label appears when there is update positioned directly below the update button and styled for visibility.
  
When there is update:
![image](https://github.com/user-attachments/assets/9d79df2b-8951-4960-b1a5-4795fc5b2778)

When no update:
![image](https://github.com/user-attachments/assets/7f6f725d-b850-4b5c-adf4-9b750589bc7b)