### PR TITLE
Add WSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [1.0.10] - 2025-05-18
+
+### Improved
+
+- **WSL Path Handling and Folder Picker Experience:**
+  - Fixed all path normalization and comparison logic for WSL folders, ensuring consistent selection, deselection, and file tree operations for WSL paths.
+  - Updated `src/utils/pathUtils.ts` and `electron/utils.js` to always normalize WSL paths to a consistent `//wsl.localhost/` or `//wsl$/` prefix.
+  - Improved folder picker dialog logic:
+    - On Windows, the folder picker now only defaults to the WSL root (`\\wsl$\`) if the last selected folder was a WSL path. Otherwise, it opens to the standard Windows location.
+    - Users can now browse and select WSL folders directly from the dialog, but Windows users who primarily use local folders are not forced into the WSL view.
+    - The renderer now sends the last selected folder to the main process for context-aware dialog behavior.
+  - Refactored `open-folder` IPC handler in `electron/main.js` to support this smarter logic and use the new `isWSLPath` utility.
+
+### Fixed
+
+- **WSL File Selection:**
+  - Resolved an issue where selecting or deselecting files/folders in WSL directories would fail with "No selectable files found in folder" due to inconsistent path normalization.
+  - Fixed edge cases where WSL paths with different slashes or UNC prefixes were not recognized as equivalent.
+
+### Technical
+
+- Added/updated utility functions in both frontend and backend for robust cross-platform path handling.
+- Improved code comments and maintainability for all path-related logic.
+- Updated CHANGELOG.md to reflect all improvements and fixes.
+
+---
+
 ## [1.0.9] - 2025-05-17
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -619,7 +619,10 @@ const App = (): JSX.Element => {
     if (isElectron) {
       console.log('Opening folder dialog');
       setProcessingStatus({ status: 'idle', message: 'Select a folder...' });
-      window.electron.ipcRenderer.send('open-folder');
+      // Send the last selected folder to the main process for smarter defaultPath logic
+      window.electron.ipcRenderer.send('open-folder', {
+        lastSelectedFolder: selectedFolder,
+      });
     } else {
       console.warn('Folder selection not available in browser');
     }


### PR DESCRIPTION
### Improved

- **WSL Path Handling and Folder Picker Experience:**
  - Fixed all path normalization and comparison logic for WSL folders, ensuring consistent selection, deselection, and file tree operations for WSL paths.
  - Updated `src/utils/pathUtils.ts` and `electron/utils.js` to always normalize WSL paths to a consistent `//wsl.localhost/` or `//wsl$/` prefix.
  - Improved folder picker dialog logic:
    - On Windows, the folder picker now only defaults to the WSL root (`\\wsl$\`) if the last selected folder was a WSL path. Otherwise, it opens to the standard Windows location.
    - Users can now browse and select WSL folders directly from the dialog, but Windows users who primarily use local folders are not forced into the WSL view.
    - The renderer now sends the last selected folder to the main process for context-aware dialog behavior.
  - Refactored `open-folder` IPC handler in `electron/main.js` to support this smarter logic and use the new `isWSLPath` utility.

### Fixed

- **WSL File Selection:**
  - Resolved an issue where selecting or deselecting files/folders in WSL directories would fail with "No selectable files found in folder" due to inconsistent path normalization.
  - Fixed edge cases where WSL paths with different slashes or UNC prefixes were not recognized as equivalent.

### Technical

- Added/updated utility functions in both frontend and backend for robust cross-platform path handling.
- Improved code comments and maintainability for all path-related logic.
- Updated CHANGELOG.md to reflect all improvements and fixes.