### PR TITLE
Add collapse/expand feature

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,7 +3,9 @@ import { SidebarProps, TreeNode } from '../types/FileTypes';
 import SearchBar from './SearchBar';
 import TreeItem from './TreeItem';
 import TaskTypeSelector from './TaskTypeSelector';
-import { ListChecks, ListX, FolderMinus, FolderPlus } from 'lucide-react';
+import { ListChecks, ListX } from 'lucide-react';
+import ExpandAllIcon from './base/ExpandAllIcon';
+import CollapseAllIcon from './base/CollapseAllIcon';
 
 /**
  * Import path utilities for handling file paths across different operating systems.
@@ -36,6 +38,8 @@ const Sidebar = ({
   onManageCustomTypes,
   collapseAllFolders,
   expandAllFolders,
+  selectedFolderNode,
+  setSelectedFolderNode,
 }: Omit<SidebarProps, 'openFolder'>) => {
   // State for managing the file tree and UI
   const [fileTree, setFileTree] = useState(() => [] as TreeNode[]);
@@ -331,9 +335,11 @@ const Sidebar = ({
         toggleFolderSelection={toggleFolderSelection}
         toggleExpanded={toggleExpanded}
         includeBinaryPaths={includeBinaryPaths}
+        selectedFolderNode={selectedFolderNode}
+        setSelectedFolderNode={setSelectedFolderNode}
       />
     ));
-  }, [visibleTree, selectedFiles, toggleFileSelection, toggleFolderSelection, toggleExpanded]);
+  }, [visibleTree, selectedFiles, toggleFileSelection, toggleFolderSelection, toggleExpanded, selectedFolderNode, setSelectedFolderNode]);
 
   return (
     <div className="sidebar" style={{ width: `${sidebarWidth}px` }}>
@@ -379,21 +385,35 @@ const Sidebar = ({
         </button>
         <button
           className="sidebar-action-btn"
-          title="Collapse all folders"
-          onClick={collapseAllFolders}
-          aria-label="Collapse all folders"
-          type="button"
+          onClick={expandAllFolders}
+          title={
+            selectedFolderNode
+              ? "Expand selected folder (click again for all folders)"
+              : "Expand all folders"
+          }
+          aria-label={
+            selectedFolderNode
+              ? "Expand selected folder (click again for all folders)"
+              : "Expand all folders"
+          }
         >
-          <FolderMinus size={18} />
+          <ExpandAllIcon />
         </button>
         <button
           className="sidebar-action-btn"
-          title="Expand all folders"
-          onClick={expandAllFolders}
-          aria-label="Expand all folders"
-          type="button"
+          onClick={collapseAllFolders}
+          title={
+            selectedFolderNode
+              ? "Collapse selected folder (click again for all folders)"
+              : "Collapse all folders"
+          }
+          aria-label={
+            selectedFolderNode
+              ? "Collapse selected folder (click again for all folders)"
+              : "Collapse all folders"
+          }
         >
-          <FolderPlus size={18} />
+          <CollapseAllIcon />
         </button>
       </div>
 

--- a/src/components/TreeItem.tsx
+++ b/src/components/TreeItem.tsx
@@ -30,6 +30,8 @@ const TreeItem = ({
   toggleFolderSelection,
   toggleExpanded,
   includeBinaryPaths,
+  selectedFolderNode,
+  setSelectedFolderNode,
 }: TreeItemProps) => {
   const { id, name, path, type, level, isExpanded, fileData } = node;
   const checkboxRef = useRef<HTMLInputElement | null>(null);
@@ -183,11 +185,13 @@ const TreeItem = ({
 
   const handleItemClick = useCallback(() => {
     if (type === 'directory') {
-      toggleExpanded(id);
+      if (setSelectedFolderNode) {
+        setSelectedFolderNode(selectedFolderNode === id ? null : id);
+      }
     } else if (type === 'file' && !isCheckboxDisabled) {
       toggleFileSelection(path);
     }
-  }, [type, id, path, toggleExpanded, toggleFileSelection, isCheckboxDisabled]);
+  }, [type, id, path, selectedFolderNode, setSelectedFolderNode, toggleFileSelection, isCheckboxDisabled]);
 
   const handleCheckboxChange = useCallback(
     (e: any) => {
@@ -219,9 +223,11 @@ const TreeItem = ({
     [type, path, toggleFileSelection, toggleFolderSelection, isCheckboxDisabled]
   );
 
+  const isFolderSelected = type === 'directory' && selectedFolderNode === id;
+
   return (
     <div
-      className={`tree-item ${isSelected ? 'selected' : ''} ${isCheckboxDisabled ? 'disabled-item' : ''}`}
+      className={`tree-item ${isSelected ? 'selected' : ''} ${isFolderSelected ? 'folder-selected' : ''} ${isCheckboxDisabled ? 'disabled-item' : ''}`}
       style={{ marginLeft: `${level * 16}px` }}
       onClick={handleItemClick}
     >

--- a/src/components/base/CollapseAllIcon.tsx
+++ b/src/components/base/CollapseAllIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const CollapseAllIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M7.41 18.59L8.83 20 12 16.83 15.17 20l1.41-1.41L12 14l-4.59 4.59zm9.18-13.18L15.17 4 12 7.17 8.83 4 7.41 5.41 12 10l4.59-4.59z"/>
+  </svg>
+);
+
+export default CollapseAllIcon;

--- a/src/components/base/ExpandAllIcon.tsx
+++ b/src/components/base/ExpandAllIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const ExpandAllIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"/>
+  </svg>
+);
+
+export default ExpandAllIcon;

--- a/src/styles/sidebar/TreeItem.css
+++ b/src/styles/sidebar/TreeItem.css
@@ -54,6 +54,10 @@
   background-color: var(--background-selected);
 }
 
+.tree-item.folder-selected {
+  background-color: var(--background-tertiary);
+}
+
 .tree-item.disabled-item {
   opacity: 0.7;
   cursor: default;

--- a/src/types/FileTypes.ts
+++ b/src/types/FileTypes.ts
@@ -46,6 +46,8 @@ export interface SidebarProps {
   currentWorkspaceName?: string | null;
   collapseAllFolders: () => void;
   expandAllFolders: () => void;
+  selectedFolderNode?: string | null;
+  setSelectedFolderNode?: (nodeId: string | null) => void;
 }
 
 export interface FileListProps {
@@ -67,6 +69,8 @@ export interface TreeItemProps {
   toggleFolderSelection: (folderPath: string, isSelected: boolean) => void;
   toggleExpanded: (nodeId: string) => void;
   includeBinaryPaths: boolean;
+  selectedFolderNode?: string | null;
+  setSelectedFolderNode?: (nodeId: string | null) => void;
 }
 
 export interface SortOption {


### PR DESCRIPTION
Add ability to collapse and expand individual folders
Pressing once with a folder selected expand only the select one, pressing a second time expands all. Similar for collapsing

https://github.com/user-attachments/assets/fcaba07a-bb96-4430-a831-ecb1b91712d2
